### PR TITLE
fixed compatibility issue with iOS7

### DIFF
--- a/YaleMobile/YMMainView.m
+++ b/YaleMobile/YMMainView.m
@@ -90,7 +90,7 @@
 
 - (void)refreshName
 {
-  if ([self.greeting.text containsString:@"Hey"]) return;
+  if ([self.greeting.text rangeOfString:@"Hey"].length != 0) return;
 
   NSString *name = [[NSUserDefaults standardUserDefaults] objectForKey:@"Name"];
   


### PR DESCRIPTION
Hey, I was pretty bummed out this past semester that YaleMobile was incompatible with my phone, which is still on iOS7.  The fix is just a line (containsString is new in iOS8) and would be very much appreciated by Luddites like me.
Thanks!
Sachith Gullapalli